### PR TITLE
Fix initial user creation

### DIFF
--- a/ankiserverctl.py
+++ b/ankiserverctl.py
@@ -69,9 +69,8 @@ def adduser(username):
         conn = sqlite3.connect(AUTHDBPATH)
         cursor = conn.cursor()
 
-        if not os.path.isfile(AUTHDBPATH):
-            cursor.execute( "CREATE TABLE auth "
-                            "(user VARCHAR PRIMARY KEY, hash VARCHAR)")
+        cursor.execute( "CREATE TABLE IF NOT EXISTS auth "
+                        "(user VARCHAR PRIMARY KEY, hash VARCHAR)")
 
         cursor.execute("INSERT INTO auth VALUES (?, ?)", (username, hash))
 


### PR DESCRIPTION
`sqlite3.connect` automatically creates a database file if it doesn't exist yet. Consequently, `os.path.isfile` will always return true, the auth table won't be created, and inserting a user will fail.
