### PR TITLE
Looks like there is a "self." missing.

### DIFF
--- a/AnkiServer/apps/sync_app.py
+++ b/AnkiServer/apps/sync_app.py
@@ -307,10 +307,8 @@ class SyncApp(object):
             self.collection_manager = getCollectionManager()
 
         # make sure the base_url has a trailing slash
-        if len(self.base_url) == 0:
-            self.base_url = '/'
-        elif self.base_url[-1] != '/':
-            self.base_url = base_url + '/'
+        if not self.base_url.endswith('/'):
+            self.base_url += '/'
 
     def generateHostKey(self, username):
         """Generates a new host key to be used by the given username to identify their session.


### PR DESCRIPTION
Hi.
I think i spotted a typo.
It said `self.base_url = base_url + '/'`, but there was no local variable `base_url` anywhere.

In the end i changed this in a slightly different way. `str.endswith()` works on empty strings, so there is no real need for the `if` _and_ `elif`.

I have also configured my Emacs so that it removes trailing whitespace on every save. I've put that in an extra commit.

I am not sure how you handle pull requests. Maybe you just want to change line 313 and add the missing `self.`. Anyway, i thought i should mention this.
Regards, ospalh
