### PR TITLE
SyncMediaHandler.begin() must return media database usn, not collection usn

### DIFF
--- a/AnkiServer/apps/sync_app.py
+++ b/AnkiServer/apps/sync_app.py
@@ -91,7 +91,13 @@ class SyncMediaHandler(MediaSyncer):
         MediaSyncer.__init__(self, col)
 
     def begin(self, skey):
-        return json.dumps({'data':{'sk':skey, 'usn':self.col._usn}, 'err':''})
+        return json.dumps({
+            'data':{
+                'sk':skey,
+                'usn':self.col.media.lastUsn()
+            },
+            'err':''
+        })
 
     def uploadChanges(self, data, skey):
         """Adds files based from ZIP file data and returns the usn."""
@@ -258,7 +264,6 @@ class SimpleUserManager(object):
     def authenticate(self, username, password):
         """
         Returns True if this username is allowed to connect with this password. False otherwise.
-
         Override this to change how users are authenticated.
         """
 
@@ -267,7 +272,6 @@ class SimpleUserManager(object):
     def username2dirname(self, username):
         """
         Returns the directory name for the given user. By default, this is just the username.
-
         Override this to adjust the mapping between users and their directory.
         """
 


### PR DESCRIPTION
If the wrong usn is returned, media syncing on the client will not finish with status "noChanges" even if there have been no changes since the last media sync.