### PR TITLE
Define an skey to return to the client when media syncing begins.

### DIFF
--- a/AnkiServer/apps/sync_app.py
+++ b/AnkiServer/apps/sync_app.py
@@ -22,6 +22,7 @@ from webob import Response
 import os
 import hashlib
 import logging
+import random
 import string
 
 import AnkiServer
@@ -202,7 +203,7 @@ class SyncMediaHandler(MediaSyncer):
 class SyncUserSession(object):
     def __init__(self, name, path, collection_manager, setup_new_collection=None):
         import time
-        self.skey = None
+        self.skey = self._generate_session_key()
         self.name = name
         self.path = path
         self.collection_manager = collection_manager
@@ -217,6 +218,9 @@ class SyncUserSession(object):
 
         self.collection_handler = None
         self.media_handler = None
+
+    def _generate_session_key(self):
+        return checksum(str(random.random()))[:8]
 
     def get_collection_path(self):
         return os.path.realpath(os.path.join(self.path, 'collection.anki2'))
@@ -548,11 +552,7 @@ class SyncApp(object):
             if url not in self.valid_urls:
                 raise HTTPNotFound()
 
-            if url == 'begin':
-                skey = checksum(str(random.random()))[:8]
-                data['skey'] = skey
-                session.skey = skey
-            elif url == 'mediaChanges' or url == 'uploadChanges':
+            if url == 'begin' or url == 'mediaChanges' or url == 'uploadChanges':
                 data['skey'] = session.skey
 
             return self._execute_handler_method_in_thread(url, data, session)

--- a/AnkiServer/apps/sync_app.py
+++ b/AnkiServer/apps/sync_app.py
@@ -548,7 +548,11 @@ class SyncApp(object):
             if url not in self.valid_urls:
                 raise HTTPNotFound()
 
-            if url == 'begin' or url == 'mediaChanges' or url == 'uploadChanges':
+            if url == 'begin':
+                skey = checksum(str(random.random()))[:8]
+                data['skey'] = skey
+                session.skey = skey
+            elif url == 'mediaChanges' or url == 'uploadChanges':
                 data['skey'] = session.skey
 
             return self._execute_handler_method_in_thread(url, data, session)


### PR DESCRIPTION
As the skey is determined by the server, we need to define one when media syncing begins (that is, before SyncMediaHandler.begin() is first called) so we don't return a null value.