### PR TITLE
Added explicit dependency on httplib2.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,11 +13,14 @@ def get_anki_bundled_files():
         data_files.append((root, [os.path.join(root, f) for f in files]))
     return data_files
 
+with open('README.rst') as f:
+    LONG_DESCRIPTION = f.read()
+
 setup(
     name="AnkiServer",
     version="2.0.6",
     description="A personal Anki sync server (so you can sync against your own server rather than AnkiWeb)",
-    long_description=open('README.rst').read(),
+    long_description=LONG_DESCRIPTION,
     license='LICENSE.txt',
     author="David Snopek",
     author_email="dsnopek@gmail.com",
@@ -27,6 +30,7 @@ setup(
         "PasteScript>=1.7.3",
         "WebOb>=0.9.7",
         "SQLAlchemy>=0.6.3",
+        "httplib2"
     ],
     tests_require=[
         'nose>=1.3.0',


### PR DESCRIPTION
Resolves #37.

Since `httplib2` is not a direct dependency of this library, an alternative way to resolve this is to maybe modify the documentation about running this in a virtualenv to include a step pulling in the anki dependencies.

Ideally we'd be able to pull in an actual dependency list from somewhere, not sure how to do that, particularly in a cross-platform way.