### PR TITLE
Fix error in format string causing behavior reported in issue #45

### DIFF
--- a/AnkiServer/apps/sync_app.py
+++ b/AnkiServer/apps/sync_app.py
@@ -233,7 +233,7 @@ class SyncMediaHandler(MediaSyncer):
                 os.remove(os.path.join(self.col.media.dir(), filename))
             except OSError as err:
                 logging.error("Error when removing file '%s' from media dir: "
-                              "%s" % filename, str(err))
+                              "%s" % (filename, str(err)))
 
     def downloadFiles(self, files):
         import zipfile


### PR DESCRIPTION
Fixes error in format string causing failure in error handler in SyncMediaHandler._remove_media_files(). 