### PR TITLE
Reject desktop clients older than 2.0.27

### DIFF
--- a/AnkiServer/apps/sync_app.py
+++ b/AnkiServer/apps/sync_app.py
@@ -57,35 +57,20 @@ class SyncCollectionHandler(Syncer):
         # So that 'server' (the 3rd argument) can't get set
         Syncer.__init__(self, col)
 
-    def meta(self, cv=None):
+    def meta(self):
         # Make sure the media database is open!
         if self.col.media.db is None:
             self.col.media.connect()
 
-        if cv is not None:
-            client, version, platform = cv.split(',')
-        else:
-            client = 'ankidesktop'
-            version = '2.0.12'
-            platform = 'unknown'
-
-        version_int = [ int(str(x).translate(None, string.ascii_letters))
-                        for x in version.split('.') ]
-
-        # Some insanity added in Anki 2.0.13
-        if (client == 'ankidroid' and version_int >= [2, 3]) \
-        or (client == 'ankidesktop' and version_int >= [2, 0, 13]):
-            return {
-              'scm': self.col.scm,
-              'ts': intTime(),
-              'mod': self.col.mod,
-              'usn': self.col._usn,
-              'musn': self.col.media.lastUsn(),
-              'msg': '',
-              'cont': True,
-            }
-        else:
-            return (self.col.mod, self.col.scm, self.col._usn, intTime(), self.col.media.lastUsn())
+        return {
+            'scm': self.col.scm,
+            'ts': intTime(),
+            'mod': self.col.mod,
+            'usn': self.col._usn,
+            'musn': self.col.media.lastUsn(),
+            'msg': '',
+            'cont': True,
+        }
 
 class SyncMediaHandler(MediaSyncer):
     operations = ['begin', 'mediaChanges', 'mediaSanity', 'mediaList', 'uploadChanges', 'downloadFiles']
@@ -569,6 +554,15 @@ class SyncApp(object):
                         del data['v']
                     if data.has_key('cv'):
                         session.client_version = data['cv']
+                        client, version, platform = data['cv'].split(',')
+                        del data['cv']
+
+                        version_int = [ int(str(x).translate(None, string.ascii_letters))
+                                        for x in version.split('.') ]
+
+                        if (client == 'ankidroid' and version_int < [2, 3, 0]) \
+                        or (client == 'ankidesktop' and version_int < [2, 0, 27]):
+                            return Response(status="501")  # client needs upgrade
                     self.session_manager.save(hkey, session)
                     session = self.session_manager.load(hkey, self.create_session)
 

--- a/AnkiServer/apps/sync_app.py
+++ b/AnkiServer/apps/sync_app.py
@@ -73,8 +73,8 @@ class SyncCollectionHandler(Syncer):
                         for x in version.split('.') ]
 
         # Some insanity added in Anki 2.0.13
-        if (client == 'ankidroid' and version_int[0] >=2 and version_int[1] >= 3) \
-        or (client == 'ankidesktop' and version_int[0] >= 2 and version_int[1] >= 0 and version_int[2] >= 13):
+        if (client == 'ankidroid' and version_int >= [2, 3]) \
+        or (client == 'ankidesktop' and version_int >= [2, 0, 13]):
             return {
               'scm': self.col.scm,
               'ts': intTime(),

--- a/tests/test_sync_app.py
+++ b/tests/test_sync_app.py
@@ -28,34 +28,6 @@ class SyncCollectionHandlerTest(CollectionTestBase):
         CollectionTestBase.tearDown(self)
         self.syncCollectionHandler = None
 
-    def test_meta(self):
-        version_info = (None,
-                        ','.join(('ankidesktop', '2.0.12', 'lin::')),
-                        ','.join(('ankidesktop', '2.0.32', 'lin::')))
-
-        meta = self.syncCollectionHandler.meta(version_info[0])
-        self.assertEqual(meta[0], self.collection.mod)
-        self.assertEqual(meta[1], self.collection.scm)
-        self.assertEqual(meta[2], self.collection._usn)
-        self.assertTrue((type(meta[3]) == int) and meta[3] > 0)
-        self.assertEqual(meta[4], self.collection.media.lastUsn())
-
-        meta = self.syncCollectionHandler.meta(version_info[1])
-        self.assertEqual(meta[0], self.collection.mod)
-        self.assertEqual(meta[1], self.collection.scm)
-        self.assertEqual(meta[2], self.collection._usn)
-        self.assertTrue((type(meta[3]) == int) and meta[3] > 0)
-        self.assertEqual(meta[4], self.collection.media.lastUsn())
-
-        meta = self.syncCollectionHandler.meta(version_info[2])
-        self.assertEqual(meta['scm'], self.collection.scm)
-        self.assertTrue((type(meta['ts']) == int) and meta['ts'] > 0)
-        self.assertEqual(meta['mod'], self.collection.mod)
-        self.assertEqual(meta['usn'], self.collection._usn)
-        self.assertEqual(meta['musn'], self.collection.media.lastUsn())
-        self.assertEqual(meta['msg'], '')
-        self.assertEqual(meta['cont'], True)
-
 
 class SimpleUserManagerTest(unittest.TestCase):
     _good_test_un = 'username'


### PR DESCRIPTION
Since merging #28, AnkiServer uses a backwards-incompatible version of the sync protocol. To prevent confusing (or silent) errors, the server should just disallow connections from older clients.

As an extra, the server compares the version correctly (2.1.0 > 2.0.41) and no longer assumes that an unknown client uses the pre-2.0.13 protocol, which is now wrong in most cases, as can be seen in #63.

Fixes #60.